### PR TITLE
added lower() so that it is easy to find movies

### DIFF
--- a/song-bot.py
+++ b/song-bot.py
@@ -67,7 +67,7 @@ def main():
         print "Movie name cannot be empty"
         sys.exit(1)
 
-    found, possible_matches = movie_finder(base_url, movie_name)
+    found, possible_matches = movie_finder(base_url, movie_name.lower())
     if found:
         print 'Movie found'
         #Let user select a movie in case of multiple matches


### PR DESCRIPTION
This was one very minute bug that I found when I used song-bot. Comparison is not made with lower()

For example if I search for movie 'Talash' it works fine but when i search for 'talash' I get 'Movie not found'. 
movie_name.lower() should help escape this.
